### PR TITLE
Fix multiplayer spawn, coin counter, shop affordability, and ProperSave coins

### DIFF
--- a/Assets.cs
+++ b/Assets.cs
@@ -11,15 +11,20 @@ namespace EphemeralCoins
 
 		public static ArtifactDef NewMoonArtifact;
 
-        internal static string[] lunarInteractables = {
-            "RoR2/Base/LunarRecycler/LunarRecycler.prefab",
-            "RoR2/Base/LunarChest/LunarChest.prefab",
-            "RoR2/Base/LunarShopTerminal/LunarShopTerminal.prefab",
-            "RoR2/Base/bazaar/SeerStation.prefab",
-            "RoR2/Base/moon/FrogInteractable.prefab"
-        };
+		internal const string PickupLunarCoin = "RoR2/Base/MiscPickups/LunarCoin/PickupLunarCoin.prefab";
+		internal const string LunarCoinMesh = "RoR2/Base/Common/VFX/Coins/mdlLunarCoin.fbx";
+		internal const string LunarCoinWithHoleMesh = "RoR2/Base/Common/VFX/Coins/mdlLunarCoinWithHole.fbx";
+		internal const string LunarCoinPlaceholderMat = "RoR2/Base/Common/VFX/Coins/matLunarCoinPlaceholder.mat";
 
-        public static string AssetBundlePath
+		internal static string[] lunarInteractables = {
+			"RoR2/Base/Interactables/LunarRecycler/LunarRecycler.prefab",
+			"RoR2/Base/Interactables/LunarChest/LunarChest.prefab",
+			"RoR2/Base/Interactables/LunarShopTerminal/LunarShopTerminal.prefab",
+			"RoR2/Base/Scenes/bazaar/SeerStation.prefab",
+			"RoR2/Base/Scenes/moon/Natural/Prefabs/FrogInteractable.prefab"
+		};
+
+		public static string AssetBundlePath
 		{
 			get
 			{
@@ -37,5 +42,5 @@ namespace EphemeralCoins
 			NewMoonArtifact.smallIconSelectedSprite = mainBundle.LoadAsset<Sprite>("texArtifactNewMoonEnabled");
 			NewMoonArtifact.smallIconDeselectedSprite = mainBundle.LoadAsset<Sprite>("texArtifactNewMoonDisabled");
 		}
-    }
+	}
 }

--- a/CoinStorage.cs
+++ b/CoinStorage.cs
@@ -1,4 +1,5 @@
-﻿using RoR2;
+﻿using System;
+using RoR2;
 using UnityEngine.Networking;
 using R2API.Networking.Interfaces;
 
@@ -13,6 +14,44 @@ namespace EphemeralCoins
         public bool Matches(NetworkUser user)
         {
             return user != null && userId.Equals(user.id);
+        }
+    }
+
+    /// <summary>
+    /// JSON-friendly ProperSave payload. Uses stable NetworkUserId fields instead of NetworkInstanceId
+    /// (master object IDs are not valid across save/load).
+    /// </summary>
+    [Serializable]
+    public class EphemeralCoinSaveEntry
+    {
+        public ulong idValue;
+        public string idStr;
+        public byte idSub;
+        public string name;
+        public uint count;
+
+        public static EphemeralCoinSaveEntry From(CoinStorage storage)
+        {
+            return new EphemeralCoinSaveEntry
+            {
+                idValue = storage.userId.value,
+                idStr = storage.userId.strValue ?? "",
+                idSub = storage.userId.subId,
+                name = storage.name,
+                count = storage.ephemeralCoinCount
+            };
+        }
+
+        public CoinStorage ToCoinStorage()
+        {
+            return new CoinStorage
+            {
+                userId = !string.IsNullOrEmpty(idStr)
+                    ? NetworkUserId.FromIp(idStr, idSub)
+                    : NetworkUserId.FromId(idValue, idSub),
+                name = name,
+                ephemeralCoinCount = count
+            };
         }
     }
 

--- a/CoinStorage.cs
+++ b/CoinStorage.cs
@@ -34,9 +34,9 @@ namespace EphemeralCoins
         {
             return new EphemeralCoinSaveEntry
             {
-                idValue = storage.userId.value,
-                idStr = storage.userId.strValue ?? "",
-                idSub = storage.userId.subId,
+                idValue = NetworkUserIdAccess.GetValue(storage.userId),
+                idStr = NetworkUserIdAccess.GetStrValue(storage.userId) ?? "",
+                idSub = NetworkUserIdAccess.GetSubId(storage.userId),
                 name = storage.name,
                 count = storage.ephemeralCoinCount
             };
@@ -110,9 +110,9 @@ namespace EphemeralCoins
 
         public void Serialize(NetworkWriter writer)
         {
-            writer.WritePackedUInt64(userId.value);
-            writer.Write(userId.strValue ?? "");
-            writer.Write(userId.subId);
+            writer.WritePackedUInt64(NetworkUserIdAccess.GetValue(userId));
+            writer.Write(NetworkUserIdAccess.GetStrValue(userId) ?? "");
+            writer.Write(NetworkUserIdAccess.GetSubId(userId));
             writer.Write(name);
             writer.Write(ephemeralCoinCount);
         }

--- a/CoinStorage.cs
+++ b/CoinStorage.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+﻿using RoR2;
 using UnityEngine.Networking;
 using R2API.Networking.Interfaces;
 
@@ -6,29 +6,39 @@ namespace EphemeralCoins
 {
     public class CoinStorage
     {
-        public NetworkInstanceId user;
+        public NetworkUserId userId;
         public string name;
         public uint ephemeralCoinCount;
+
+        public bool Matches(NetworkUser user)
+        {
+            return user != null && userId.Equals(user.id);
+        }
     }
 
     public class SyncCoinStorage : INetMessage
     {
-        public NetworkInstanceId user;
+        public NetworkUserId userId;
         public string name;
         public uint ephemeralCoinCount;
 
         public SyncCoinStorage(){}
 
-        public SyncCoinStorage(NetworkInstanceId user, string name, uint ephemeralCoinCount)
+        public SyncCoinStorage(NetworkUserId userId, string name, uint ephemeralCoinCount)
         {
-            this.user = user;
+            this.userId = userId;
             this.name = name;
             this.ephemeralCoinCount = ephemeralCoinCount;
         }
 
         public void Deserialize(NetworkReader reader)
         {
-            user = reader.ReadNetworkId();
+            ulong value = reader.ReadPackedUInt64();
+            string strValue = reader.ReadString();
+            byte subId = reader.ReadByte();
+            userId = !string.IsNullOrEmpty(strValue)
+                ? NetworkUserId.FromIp(strValue, subId)
+                : NetworkUserId.FromId(value, subId);
             name = reader.ReadString();
             ephemeralCoinCount = reader.ReadUInt32();
         }
@@ -41,14 +51,14 @@ namespace EphemeralCoins
                 return;
             }
             CoinStorage newPlayer = new CoinStorage();
-            newPlayer.user = user;
+            newPlayer.userId = userId;
             newPlayer.name = name;
             newPlayer.ephemeralCoinCount = ephemeralCoinCount;
 
             bool flag = false;
             foreach (CoinStorage player in EphemeralCoins.instance.coinCounts)
             {
-                if (player.user.Equals(newPlayer.user))
+                if (player.userId.Equals(newPlayer.userId))
                 {
                     player.name = newPlayer.name;
                     player.ephemeralCoinCount = newPlayer.ephemeralCoinCount;
@@ -61,7 +71,9 @@ namespace EphemeralCoins
 
         public void Serialize(NetworkWriter writer)
         {
-            writer.Write(user);
+            writer.WritePackedUInt64(userId.value);
+            writer.Write(userId.strValue ?? "");
+            writer.Write(userId.subId);
             writer.Write(name);
             writer.Write(ephemeralCoinCount);
         }

--- a/CoinStorage.cs
+++ b/CoinStorage.cs
@@ -13,7 +13,20 @@ namespace EphemeralCoins
 
         public bool Matches(NetworkUser user)
         {
-            return user != null && userId.Equals(user.id);
+            if (user == null) return false;
+            if (userId.Equals(user.id)) return true;
+            // ProperSave reload can change NetworkUserId shape; fall back to stable display name.
+            return !string.IsNullOrEmpty(name)
+                && !string.IsNullOrEmpty(user.userName)
+                && string.Equals(name, user.userName, StringComparison.Ordinal);
+        }
+
+        public bool Matches(NetworkUserId id, string userName)
+        {
+            if (userId.Equals(id)) return true;
+            return !string.IsNullOrEmpty(name)
+                && !string.IsNullOrEmpty(userName)
+                && string.Equals(name, userName, StringComparison.Ordinal);
         }
     }
 
@@ -89,23 +102,26 @@ namespace EphemeralCoins
                 EphemeralCoins.Logger.LogWarning("SyncCoinStorage: Host ran this. Skipping.");
                 return;
             }
-            CoinStorage newPlayer = new CoinStorage();
-            newPlayer.userId = userId;
-            newPlayer.name = name;
-            newPlayer.ephemeralCoinCount = ephemeralCoinCount;
 
-            bool flag = false;
+            if (EphemeralCoins.instance == null) return;
+
             foreach (CoinStorage player in EphemeralCoins.instance.coinCounts)
             {
-                if (player.userId.Equals(newPlayer.userId))
+                if (player.Matches(userId, name))
                 {
-                    player.name = newPlayer.name;
-                    player.ephemeralCoinCount = newPlayer.ephemeralCoinCount;
-                    flag = true;
-                    break;
+                    player.userId = userId;
+                    if (!string.IsNullOrEmpty(name)) player.name = name;
+                    player.ephemeralCoinCount = ephemeralCoinCount;
+                    return;
                 }
             }
-            if (!flag) EphemeralCoins.instance.coinCounts.Add(newPlayer);
+
+            EphemeralCoins.instance.coinCounts.Add(new CoinStorage
+            {
+                userId = userId,
+                name = name,
+                ephemeralCoinCount = ephemeralCoinCount
+            });
         }
 
         public void Serialize(NetworkWriter writer)

--- a/EphemeralCoins.cs
+++ b/EphemeralCoins.cs
@@ -155,39 +155,37 @@ namespace EphemeralCoins
         }
 
         ///
-        /// Override the CostType delegates so that we can use a different coin count check when the artifact is active. Hacky, but works.
+        /// Override LunarCoin affordability so shops check ephemeral balance when the artifact is active.
+        /// CostTypeCatalog.Register is private on runtime RoR2.dll — mutate the existing CostTypeDef instead.
         /// 
         public void AddCostType()
         {
-            CostTypeDef newdef = new CostTypeDef
+            try
             {
-                costStringFormatToken = "COST_LUNARCOIN_FORMAT",
-                saturateWorldStyledCostString = false,
-                darkenWorldStyledCostString = true,
-                isAffordable = delegate (CostTypeDef costTypeDef, CostTypeDef.IsAffordableContext context)
+                CostTypeDef def = CostTypeCatalog.GetCostTypeDef(CostTypeIndex.LunarCoin);
+                if (def == null)
                 {
-                    NetworkUser networkUser2 = Util.LookUpBodyNetworkUser(context.activator.gameObject);
-                    if (!(bool)networkUser2) return false;
+                    Logger.LogWarning("LunarCoin CostTypeDef missing; shop affordability override skipped.");
+                    return;
+                }
+
+                def.isAffordable = delegate (CostTypeDef costTypeDef, CostTypeDef.IsAffordableContext context)
+                {
+                    NetworkUser networkUser = Util.LookUpBodyNetworkUser(context.activator.gameObject);
+                    if (!(bool)networkUser) return false;
                     // When the artifact is active, never fall back to profile/lunarCoins — that lets shops ignore ephemeral balance.
                     if (artifactEnabled)
                     {
-                        return getCoinsFromUser(networkUser2) >= context.cost;
+                        return getCoinsFromUser(networkUser) >= context.cost;
                     }
-                    return networkUser2.lunarCoins >= context.cost;
-                },
-                payCost = delegate (CostTypeDef.PayCostContext context, CostTypeDef.PayCostResults results)
-                {
-                    NetworkUser networkUser = Util.LookUpBodyNetworkUser(context.activator.gameObject);
-                    if ((bool)networkUser)
-                    {
-                        networkUser.DeductLunarCoins((uint)context.cost);
-                        RoR2.Items.MultiShopCardUtils.OnNonMoneyPurchase(context);
-                    }
-                },
-                colorIndex = ColorCatalog.ColorIndex.LunarCoin
-            };
-
-            CostTypeCatalog.Register(CostTypeIndex.LunarCoin, newdef);
+                    return networkUser.lunarCoins >= context.cost;
+                };
+                Logger.LogDebug("LunarCoin isAffordable delegate overridden.");
+            }
+            catch (System.Exception ex)
+            {
+                Logger.LogError("Failed to override LunarCoin affordability (load will continue): " + ex);
+            }
         }
 
         public void AlwaysOnMode()

--- a/EphemeralCoins.cs
+++ b/EphemeralCoins.cs
@@ -15,11 +15,13 @@ namespace EphemeralCoins
     [NetworkCompatibility(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]
     [BepInDependency("com.KingEnderBrine.ProperSave", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("com.rune580.riskofoptions", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInPlugin("com.Varna.EphemeralCoins", "Ephemeral_Coins", "2.3.9")]
+    [BepInPlugin("com.Varna.EphemeralCoins", "Ephemeral_Coins", "2.3.10")]
     public class EphemeralCoins : BaseUnityPlugin
     {
         public int numTimesRerolled;
         public List<CoinStorage> coinCounts = new List<CoinStorage>();
+        /// <summary>Set when ProperSave restores coin counts so Run.Start does not treat the load as a blank slate.</summary>
+        public bool restoredCoinCountsFromSave;
 
         public bool artifactEnabled {
             get
@@ -52,8 +54,7 @@ namespace EphemeralCoins
 
             NetworkingAPI.RegisterMessageType<SyncCoinStorage>();
 
-            //Utterly broken, fix later
-            //if (ProperSaveCompatibility.enabled) ProperSaveSetup();
+            if (ProperSaveCompatibility.enabled) ProperSaveCompatibility.Setup();
         }
 
         ///
@@ -62,7 +63,11 @@ namespace EphemeralCoins
         ///
         public void SetupCoinStorage(List<CoinStorage> coinStorage, bool NewRun = true)
         {
-            if (NewRun) coinStorage.Clear();
+            if (NewRun)
+            {
+                coinStorage.Clear();
+                restoredCoinCountsFromSave = false;
+            }
             foreach (NetworkUser user in NetworkUser.readOnlyInstancesList)
             {
                 // Skipping over Disconnected Players.
@@ -195,24 +200,29 @@ namespace EphemeralCoins
             }
         }
 
-        /*
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public void ProperSaveSetup()
+        public void ApplySavedCoinCounts(List<EphemeralCoinSaveEntry> saved)
         {
-            ProperSave.SaveFile.OnGatherSaveData += (dict) =>
+            coinCounts.Clear();
+            if (saved == null)
             {
-                if (dict.ContainsKey("ephemeralCoinCount"))
-                    dict["ephemeralCoinCount"] = coinCounts;
-                else
-                    dict.Add("ephemeralCoinCount", coinCounts);
-            };
+                restoredCoinCountsFromSave = false;
+                return;
+            }
 
-            ProperSave.Loading.OnLoadingEnded += (save) =>
+            foreach (EphemeralCoinSaveEntry entry in saved)
             {
-                coinCounts = save.GetModdedData<List<CoinStorage>>("ephemeralCoinCount");
-            };
+                if (entry == null) continue;
+                CoinStorage player = entry.ToCoinStorage();
+                coinCounts.Add(player);
+                if (NetworkServer.active)
+                {
+                    new SyncCoinStorage(player.userId, player.name, player.ephemeralCoinCount).Send(NetworkDestination.Clients);
+                }
+            }
+
+            restoredCoinCountsFromSave = true;
+            Logger.LogInfo("ProperSave: restored " + coinCounts.Count + " ephemeral coin entr" + (coinCounts.Count == 1 ? "y" : "ies") + ".");
         }
-        */
 
         ///
         /// Required for BTB to change the costs of the pre-loaded prefab instances.

--- a/EphemeralCoins.cs
+++ b/EphemeralCoins.cs
@@ -6,6 +6,7 @@ using RoR2;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Networking;
 
 namespace EphemeralCoins
 {
@@ -14,7 +15,7 @@ namespace EphemeralCoins
     [NetworkCompatibility(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]
     [BepInDependency("com.KingEnderBrine.ProperSave", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("com.rune580.riskofoptions", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInPlugin("com.Varna.EphemeralCoins", "Ephemeral_Coins", "2.3.8")]
+    [BepInPlugin("com.Varna.EphemeralCoins", "Ephemeral_Coins", "2.3.9")]
     public class EphemeralCoins : BaseUnityPlugin
     {
         public int numTimesRerolled;
@@ -57,6 +58,7 @@ namespace EphemeralCoins
 
         ///
         /// Based on the PlayerStorage system used in https://github.com/WondaMegapon/Refightilization/blob/master/Refightilization/Refightilization.cs
+        /// Keys players by NetworkUserId (stable) rather than Network_masterObjectId (can be invalid early / mid-run).
         ///
         public void SetupCoinStorage(List<CoinStorage> coinStorage, bool NewRun = true)
         {
@@ -76,7 +78,7 @@ namespace EphemeralCoins
                     bool flag = false;
                     foreach (CoinStorage player in coinStorage)
                     {
-                        if (player.user.Equals(user.id))
+                        if (player.Matches(user))
                         {
                             flag = true;
                             break;
@@ -84,47 +86,59 @@ namespace EphemeralCoins
                     }
                     if (flag) continue;
                 }
-                CoinStorage newPlayer = new CoinStorage();
-                newPlayer.user = user.Network_masterObjectId;
-                newPlayer.name = user.userName;
-                newPlayer.ephemeralCoinCount = 0;
-                coinStorage.Add(newPlayer);
+                // Sync from setup only — award/deduct RPCs already update every peer.
+                CoinStorage newPlayer = EnsureUser(user, syncToClients: true);
                 Logger.LogDebug(newPlayer.name + " added to CoinStorage!");
-                new SyncCoinStorage(newPlayer.user, newPlayer.name, 0).Send(NetworkDestination.Clients);
             }
             Logger.LogDebug("Setting up CoinStorage finished.");
         }
 
-        public void giveCoinsToUser(NetworkUser user, uint count)
+        public CoinStorage EnsureUser(NetworkUser user, bool syncToClients = false)
         {
+            if (user == null) return null;
             foreach (CoinStorage player in coinCounts)
             {
-                if (player.user.Equals(user.Network_masterObjectId))
+                if (player.Matches(user))
                 {
-                    player.ephemeralCoinCount += count;
-                    Logger.LogDebug("giveCoinsToUser: " + user.userName + " " + count);
+                    if (string.IsNullOrEmpty(player.name)) player.name = user.userName;
+                    return player;
                 }
             }
+            CoinStorage newPlayer = new CoinStorage();
+            newPlayer.userId = user.id;
+            newPlayer.name = user.userName;
+            newPlayer.ephemeralCoinCount = 0;
+            coinCounts.Add(newPlayer);
+            if (syncToClients && NetworkServer.active)
+            {
+                new SyncCoinStorage(newPlayer.userId, newPlayer.name, newPlayer.ephemeralCoinCount).Send(NetworkDestination.Clients);
+            }
+            return newPlayer;
+        }
+
+        public void giveCoinsToUser(NetworkUser user, uint count)
+        {
+            CoinStorage player = EnsureUser(user);
+            if (player == null) return;
+            player.ephemeralCoinCount += count;
+            Logger.LogDebug("giveCoinsToUser: " + user.userName + " " + count + " -> " + player.ephemeralCoinCount);
         }
 
         public void takeCoinsFromUser(NetworkUser user, uint count)
         {
-            foreach (CoinStorage player in coinCounts)
-            {
-                if (player.user.Equals(user.Network_masterObjectId))
-                {
-                    player.ephemeralCoinCount -= count;
-                    Logger.LogDebug("takeCoinsFromUser: " + user.userName + " " + count);
-                }
-            }
+            CoinStorage player = EnsureUser(user);
+            if (player == null) return;
+            if (count > player.ephemeralCoinCount) player.ephemeralCoinCount = 0;
+            else player.ephemeralCoinCount -= count;
+            Logger.LogDebug("takeCoinsFromUser: " + user.userName + " " + count + " -> " + player.ephemeralCoinCount);
         }
 
         public uint getCoinsFromUser(NetworkUser user)
         {
-            if (Run.instance != null) {
+            if (Run.instance != null && user != null) {
                 foreach (CoinStorage player in coinCounts)
                 {
-                    if (player.user.Equals(user.Network_masterObjectId))
+                    if (player.Matches(user))
                     {
                         //Spams the console due to HUD hook, only used for debugging.
                         //Logger.LogDebug("getCoinsFromUser: " + user.userName + player.ephemeralCoinCount);
@@ -148,16 +162,13 @@ namespace EphemeralCoins
                 isAffordable = delegate (CostTypeDef costTypeDef, CostTypeDef.IsAffordableContext context)
                 {
                     NetworkUser networkUser2 = Util.LookUpBodyNetworkUser(context.activator.gameObject);
-                    if (artifactEnabled) {
-                        foreach (CoinStorage player in coinCounts)
-                        {
-                            if (player.user.Equals(networkUser2.Network_masterObjectId))
-                            {
-                                return player.ephemeralCoinCount >= context.cost;
-                            }
-                        }
+                    if (!(bool)networkUser2) return false;
+                    // When the artifact is active, never fall back to profile/lunarCoins — that lets shops ignore ephemeral balance.
+                    if (artifactEnabled)
+                    {
+                        return getCoinsFromUser(networkUser2) >= context.cost;
                     }
-                    return (bool)networkUser2 && networkUser2.lunarCoins >= context.cost;
+                    return networkUser2.lunarCoins >= context.cost;
                 },
                 payCost = delegate (CostTypeDef.PayCostContext context, CostTypeDef.PayCostResults results)
                 {

--- a/EphemeralCoins.cs
+++ b/EphemeralCoins.cs
@@ -14,7 +14,7 @@ namespace EphemeralCoins
     [NetworkCompatibility(CompatibilityLevel.EveryoneMustHaveMod, VersionStrictness.EveryoneNeedSameModVersion)]
     [BepInDependency("com.KingEnderBrine.ProperSave", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("com.rune580.riskofoptions", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInPlugin("com.Varna.EphemeralCoins", "Ephemeral_Coins", "2.3.6")]
+    [BepInPlugin("com.Varna.EphemeralCoins", "Ephemeral_Coins", "2.3.8")]
     public class EphemeralCoins : BaseUnityPlugin
     {
         public int numTimesRerolled;

--- a/EphemeralCoins.cs
+++ b/EphemeralCoins.cs
@@ -67,6 +67,7 @@ namespace EphemeralCoins
             {
                 coinStorage.Clear();
                 restoredCoinCountsFromSave = false;
+                if (ProperSaveCompatibility.enabled) ProperSaveCompatibility.ClearRestoredSnapshot();
             }
             foreach (NetworkUser user in NetworkUser.readOnlyInstancesList)
             {
@@ -80,35 +81,45 @@ namespace EphemeralCoins
                 // If this is ran mid-stage, just skip over existing players and add anybody who joined.
                 if (!NewRun && coinStorage != null)
                 {
-                    bool flag = false;
-                    foreach (CoinStorage player in coinStorage)
+                    CoinStorage existing = FindUser(user);
+                    if (existing != null)
                     {
-                        if (player.Matches(user))
-                        {
-                            flag = true;
-                            break;
-                        }
+                        existing.userId = user.id;
+                        if (string.IsNullOrEmpty(existing.name)) existing.name = user.userName;
+                        continue;
                     }
-                    if (flag) continue;
                 }
-                // Sync from setup only — award/deduct RPCs already update every peer.
-                CoinStorage newPlayer = EnsureUser(user, syncToClients: true);
+                CoinStorage newPlayer = EnsureUser(user, syncToClients: false);
                 Logger.LogDebug(newPlayer.name + " added to CoinStorage!");
             }
+
+            // Clients need a full authority push after setup/restore (id rebinds included).
+            SyncAllCoinCountsToClients();
             Logger.LogDebug("Setting up CoinStorage finished.");
+        }
+
+        public CoinStorage FindUser(NetworkUser user)
+        {
+            if (user == null) return null;
+            foreach (CoinStorage player in coinCounts)
+            {
+                if (player.Matches(user)) return player;
+            }
+            return null;
         }
 
         public CoinStorage EnsureUser(NetworkUser user, bool syncToClients = false)
         {
             if (user == null) return null;
-            foreach (CoinStorage player in coinCounts)
+            CoinStorage existing = FindUser(user);
+            if (existing != null)
             {
-                if (player.Matches(user))
-                {
-                    if (string.IsNullOrEmpty(player.name)) player.name = user.userName;
-                    return player;
-                }
+                // Rebind id after ProperSave reload when saved id shape differs from live id.
+                existing.userId = user.id;
+                if (string.IsNullOrEmpty(existing.name)) existing.name = user.userName;
+                return existing;
             }
+
             CoinStorage newPlayer = new CoinStorage();
             newPlayer.userId = user.id;
             newPlayer.name = user.userName;
@@ -121,35 +132,52 @@ namespace EphemeralCoins
             return newPlayer;
         }
 
+        public void SyncAllCoinCountsToClients()
+        {
+            if (!NetworkServer.active) return;
+            foreach (CoinStorage player in coinCounts)
+            {
+                if (player == null) continue;
+                new SyncCoinStorage(player.userId, player.name, player.ephemeralCoinCount).Send(NetworkDestination.Clients);
+            }
+        }
+
         public void giveCoinsToUser(NetworkUser user, uint count)
         {
+            // ProperSave load can replay lunar award RPCs; ignore while loading.
+            if (ProperSaveCompatibility.enabled && ProperSaveCompatibility.IsLoading()) return;
+
             CoinStorage player = EnsureUser(user);
             if (player == null) return;
             player.ephemeralCoinCount += count;
+            if (NetworkServer.active)
+            {
+                new SyncCoinStorage(player.userId, player.name, player.ephemeralCoinCount).Send(NetworkDestination.Clients);
+            }
             Logger.LogDebug("giveCoinsToUser: " + user.userName + " " + count + " -> " + player.ephemeralCoinCount);
         }
 
         public void takeCoinsFromUser(NetworkUser user, uint count)
         {
+            // ProperSave load can replay lunar deduct RPCs; ignore while loading.
+            if (ProperSaveCompatibility.enabled && ProperSaveCompatibility.IsLoading()) return;
+
             CoinStorage player = EnsureUser(user);
             if (player == null) return;
             if (count > player.ephemeralCoinCount) player.ephemeralCoinCount = 0;
             else player.ephemeralCoinCount -= count;
+            if (NetworkServer.active)
+            {
+                new SyncCoinStorage(player.userId, player.name, player.ephemeralCoinCount).Send(NetworkDestination.Clients);
+            }
             Logger.LogDebug("takeCoinsFromUser: " + user.userName + " " + count + " -> " + player.ephemeralCoinCount);
         }
 
         public uint getCoinsFromUser(NetworkUser user)
         {
             if (Run.instance != null && user != null) {
-                foreach (CoinStorage player in coinCounts)
-                {
-                    if (player.Matches(user))
-                    {
-                        //Spams the console due to HUD hook, only used for debugging.
-                        //Logger.LogDebug("getCoinsFromUser: " + user.userName + player.ephemeralCoinCount);
-                        return player.ephemeralCoinCount;
-                    }
-                }
+                CoinStorage player = FindUser(user);
+                if (player != null) return player.ephemeralCoinCount;
             }
             return 0;
         }
@@ -210,12 +238,21 @@ namespace EphemeralCoins
             foreach (EphemeralCoinSaveEntry entry in saved)
             {
                 if (entry == null) continue;
-                CoinStorage player = entry.ToCoinStorage();
-                coinCounts.Add(player);
-                if (NetworkServer.active)
+                coinCounts.Add(entry.ToCoinStorage());
+            }
+
+            // Rebind live NetworkUsers (id shape can differ after ProperSave reload) then push to clients.
+            if (NetworkServer.active)
+            {
+                foreach (NetworkUser user in NetworkUser.readOnlyInstancesList)
                 {
-                    new SyncCoinStorage(player.userId, player.name, player.ephemeralCoinCount).Send(NetworkDestination.Clients);
+                    if (user == null) continue;
+                    CoinStorage player = FindUser(user);
+                    if (player == null) continue;
+                    player.userId = user.id;
+                    player.name = user.userName;
                 }
+                SyncAllCoinCountsToClients();
             }
 
             restoredCoinCountsFromSave = true;

--- a/EphemeralCoins.csproj
+++ b/EphemeralCoins.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.3.9</Version>
+    <Version>2.3.10</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/EphemeralCoins.csproj
+++ b/EphemeralCoins.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.3.8</Version>
+    <Version>2.3.9</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/EphemeralCoins.csproj
+++ b/EphemeralCoins.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -16,12 +16,18 @@
 
   <ItemGroup>
     <Compile Remove="EphemeralCoins\**" />
+    <Compile Remove="EphemeralCoinsMultiplayerPatch\**" />
+    <Compile Remove="Ephemeral Coins Multiplayer Patch\**" />
     <Compile Remove="plugins\**" />
     <Compile Remove="UnityProject\**" />
     <EmbeddedResource Remove="EphemeralCoins\**" />
+    <EmbeddedResource Remove="EphemeralCoinsMultiplayerPatch\**" />
+    <EmbeddedResource Remove="Ephemeral Coins Multiplayer Patch\**" />
     <EmbeddedResource Remove="plugins\**" />
     <EmbeddedResource Remove="UnityProject\**" />
     <None Remove="EphemeralCoins\**" />
+    <None Remove="EphemeralCoinsMultiplayerPatch\**" />
+    <None Remove="Ephemeral Coins Multiplayer Patch\**" />
     <None Remove="plugins\**" />
     <None Remove="UnityProject\**" />
   </ItemGroup>

--- a/EphemeralCoins.csproj
+++ b/EphemeralCoins.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.3.3</Version>
+    <Version>2.3.8</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Hooks.cs
+++ b/Hooks.cs
@@ -29,10 +29,19 @@ namespace EphemeralCoins
             //Coin base drop chance
             On.RoR2.PlayerCharacterMasterController.Awake += PlayerCharacterMasterController_Awake;
 
-            //Coin drop multiplier
-            BindingFlags allFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
-            var initDelegate = typeof(PlayerCharacterMasterController).GetNestedTypes(allFlags)[0].GetRuntimeMethods().First(x => x.Name.StartsWith("<Init>b__"));
-            MonoMod.RuntimeDetour.HookGen.HookEndpointManager.Modify(initDelegate, (Action<ILContext>)CoinDropHook);
+            //Coin drop multiplier (compiler-generated name changes across game updates)
+            try
+            {
+                BindingFlags allFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+                var initDelegate = typeof(PlayerCharacterMasterController).GetNestedTypes(allFlags)[0]
+                    .GetRuntimeMethods()
+                    .First(x => x.Name.StartsWith("<Init>b__", StringComparison.Ordinal));
+                MonoMod.RuntimeDetour.HookGen.HookEndpointManager.Modify(initDelegate, (Action<ILContext>)CoinDropHook);
+            }
+            catch (Exception ex)
+            {
+                EphemeralCoins.Logger.LogError("Failed to IL-hook lunar coin drop multiplier; drop multi/min configs will not apply. " + ex);
+            }
 
             //Blue Orb on stage start chance reduction
             On.RoR2.TeleporterInteraction.Start += TeleporterInteraction_Start;

--- a/Hooks.cs
+++ b/Hooks.cs
@@ -1,4 +1,4 @@
-﻿using BepInEx;
+using BepInEx;
 using MonoMod.Cil;
 using R2API.Utils;
 using RoR2;
@@ -75,16 +75,24 @@ namespace EphemeralCoins
 
             // Always ensure coin storage exists when the artifact is on (includes ProperSave loads).
             // Only award starting coins / intro chat on a fresh run.
-            // ProperSave loads restore counts via OnLoadingEnded; never clear that restored data here.
+            // ProperSave loads restore via OnLoadingEnded; preserve only during that load window.
             if (NetworkServer.active && EphemeralCoins.instance.artifactEnabled)
             {
                 bool isNewRun;
-                if (ProperSaveCompatibility.enabled) { isNewRun = ProperSaveCompatibility.IsRunNew(); }
-                else { isNewRun = Run.instance.stageClearCount == 0; }
-
-                if (EphemeralCoins.instance.restoredCoinCountsFromSave)
+                if (ProperSaveCompatibility.enabled)
                 {
-                    isNewRun = false;
+                    isNewRun = !ProperSaveCompatibility.IsLoading()
+                        && !ProperSaveCompatibility.ShouldPreserveRestoredCoins;
+                }
+                else
+                {
+                    isNewRun = Run.instance.stageClearCount == 0;
+                }
+
+                if (isNewRun)
+                {
+                    EphemeralCoins.instance.restoredCoinCountsFromSave = false;
+                    if (ProperSaveCompatibility.enabled) ProperSaveCompatibility.ClearRestoredSnapshot();
                 }
 
                 EphemeralCoins.instance.SetupCoinStorage(EphemeralCoins.instance.coinCounts, isNewRun);
@@ -123,7 +131,11 @@ namespace EphemeralCoins
             if (EphemeralCoins.instance.artifactEnabled)
             {
                 orig(self, 0);
-                EphemeralCoins.instance.giveCoinsToUser(self, count);
+                // ProperSave load can replay lunar award RPCs; ignore while loading.
+                if (!ProperSaveCompatibility.enabled || !ProperSaveCompatibility.IsLoading())
+                {
+                    EphemeralCoins.instance.giveCoinsToUser(self, count);
+                }
                 self.SyncLunarCoinsToServer();
             }
             else orig(self, count);
@@ -134,7 +146,11 @@ namespace EphemeralCoins
             if (EphemeralCoins.instance.artifactEnabled)
             {
                 orig(self, 0);
-                EphemeralCoins.instance.takeCoinsFromUser(self, count);
+                // ProperSave load can replay lunar deduct RPCs; ignore while loading.
+                if (!ProperSaveCompatibility.enabled || !ProperSaveCompatibility.IsLoading())
+                {
+                    EphemeralCoins.instance.takeCoinsFromUser(self, count);
+                }
                 self.SyncLunarCoinsToServer();
             }
             else orig(self, count);

--- a/Hooks.cs
+++ b/Hooks.cs
@@ -62,11 +62,17 @@ namespace EphemeralCoins
 
             // Always ensure coin storage exists when the artifact is on (includes ProperSave loads).
             // Only award starting coins / intro chat on a fresh run.
+            // ProperSave loads restore counts via OnLoadingEnded; never clear that restored data here.
             if (NetworkServer.active && EphemeralCoins.instance.artifactEnabled)
             {
                 bool isNewRun;
                 if (ProperSaveCompatibility.enabled) { isNewRun = ProperSaveCompatibility.IsRunNew(); }
                 else { isNewRun = Run.instance.stageClearCount == 0; }
+
+                if (EphemeralCoins.instance.restoredCoinCountsFromSave)
+                {
+                    isNewRun = false;
+                }
 
                 EphemeralCoins.instance.SetupCoinStorage(EphemeralCoins.instance.coinCounts, isNewRun);
                 if (isNewRun)

--- a/Hooks.cs
+++ b/Hooks.cs
@@ -11,6 +11,11 @@ namespace EphemeralCoins
 {
     public class Hooks
     {
+        // HUD._localUserViewer is private on runtime RoR2.dll (publicizer is compile-only).
+        private static readonly FieldInfo LocalUserViewerField = typeof(RoR2.UI.HUD).GetField(
+            "_localUserViewer",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
         public static void Init()
         {
             //main setup hook; this is where most of the mod's settings are applied
@@ -60,6 +65,14 @@ namespace EphemeralCoins
         {
             orig(self);
 
+            // Always-on mode runs PrefabSetup during onLoad before PickupCatalog is ready.
+            // Re-apply visuals on every peer once the run has started (artifact mode also
+            // re-applies via NewMoonArtifactManager.Run_Start; this covers always-on).
+            if (EphemeralCoins.instance.artifactEnabled)
+            {
+                NewMoonArtifactManager.PrefabSetup(true);
+            }
+
             // Always ensure coin storage exists when the artifact is on (includes ProperSave loads).
             // Only award starting coins / intro chat on a fresh run.
             // ProperSave loads restore counts via OnLoadingEnded; never clear that restored data here.
@@ -88,7 +101,8 @@ namespace EphemeralCoins
             orig(self);
             if (EphemeralCoins.instance.artifactEnabled)
             {
-                NetworkUser networkUser = self._localUserViewer != null ? self._localUserViewer.currentNetworkUser : null;
+                LocalUser localUser = LocalUserViewerField?.GetValue(self) as LocalUser;
+                NetworkUser networkUser = localUser != null ? localUser.currentNetworkUser : null;
                 if (networkUser != null)
                 {
                     self.lunarCoinText.targetValue = (int)EphemeralCoins.instance.getCoinsFromUser(networkUser);

--- a/Hooks.cs
+++ b/Hooks.cs
@@ -60,15 +60,17 @@ namespace EphemeralCoins
         {
             orig(self);
 
-            //Start message + starting coins functionality
+            // Always ensure coin storage exists when the artifact is on (includes ProperSave loads).
+            // Only award starting coins / intro chat on a fresh run.
             if (NetworkServer.active && EphemeralCoins.instance.artifactEnabled)
             {
-                bool check;
-                if (ProperSaveCompatibility.enabled) { check = ProperSaveCompatibility.IsRunNew(); }
-                else { check = Run.instance.stageClearCount == 0 ? true : false; }
-                if (check)
+                bool isNewRun;
+                if (ProperSaveCompatibility.enabled) { isNewRun = ProperSaveCompatibility.IsRunNew(); }
+                else { isNewRun = Run.instance.stageClearCount == 0; }
+
+                EphemeralCoins.instance.SetupCoinStorage(EphemeralCoins.instance.coinCounts, isNewRun);
+                if (isNewRun)
                 {
-                    EphemeralCoins.instance.SetupCoinStorage(EphemeralCoins.instance.coinCounts);
                     EphemeralCoins.instance.StartCoroutine(EphemeralCoins.instance.DelayedStartingLunarCoins());
                 }
             }
@@ -80,7 +82,11 @@ namespace EphemeralCoins
             orig(self);
             if (EphemeralCoins.instance.artifactEnabled)
             {
-                self.lunarCoinText.targetValue = (int)EphemeralCoins.instance.getCoinsFromUser(self._localUserViewer.currentNetworkUser);
+                NetworkUser networkUser = self._localUserViewer != null ? self._localUserViewer.currentNetworkUser : null;
+                if (networkUser != null)
+                {
+                    self.lunarCoinText.targetValue = (int)EphemeralCoins.instance.getCoinsFromUser(networkUser);
+                }
                 if (self.lunarCoinContainer.transform.Find("LunarCoinSign") != null) self.lunarCoinContainer.transform.Find("LunarCoinSign").GetComponent<RoR2.UI.HGTextMeshProUGUI>().text = "<sprite name=\"LunarCoin\" color=#adf2fa>";
             }
         }

--- a/ModCompatibility.cs
+++ b/ModCompatibility.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using BepInEx.Configuration;
 using RiskOfOptions.OptionConfigs;
 using RiskOfOptions.Options;
@@ -7,6 +9,8 @@ namespace EphemeralCoins
 {
     public static class ProperSaveCompatibility
     {
+        public const string SaveDataKey = "EphemeralCoins.coinCounts";
+
         private static bool? _enabled;
 
         public static bool enabled
@@ -24,6 +28,52 @@ namespace EphemeralCoins
         public static bool IsRunNew()
         {
             return !ProperSave.Loading.IsLoading;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void Setup()
+        {
+            ProperSave.SaveFile.OnGatherSaveData += OnGatherSaveData;
+            ProperSave.Loading.OnLoadingEnded += OnLoadingEnded;
+            EphemeralCoins.Logger.LogInfo("ProperSave compatibility enabled (ephemeral coin save/load).");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void OnGatherSaveData(Dictionary<string, object> dict)
+        {
+            if (EphemeralCoins.instance == null) return;
+
+            List<EphemeralCoinSaveEntry> entries = new List<EphemeralCoinSaveEntry>();
+            foreach (CoinStorage player in EphemeralCoins.instance.coinCounts)
+            {
+                if (player == null) continue;
+                entries.Add(EphemeralCoinSaveEntry.From(player));
+            }
+
+            dict[SaveDataKey] = entries;
+            EphemeralCoins.Logger.LogDebug("ProperSave: gathered " + entries.Count + " ephemeral coin entries.");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void OnLoadingEnded(ProperSave.SaveFile save)
+        {
+            if (EphemeralCoins.instance == null || save == null) return;
+
+            try
+            {
+                List<EphemeralCoinSaveEntry> entries = save.TryGetModdedData<List<EphemeralCoinSaveEntry>>(SaveDataKey);
+                if (entries == null)
+                {
+                    EphemeralCoins.Logger.LogDebug("ProperSave: no ephemeral coin data in save (starting at 0).");
+                    return;
+                }
+
+                EphemeralCoins.instance.ApplySavedCoinCounts(entries);
+            }
+            catch (Exception ex)
+            {
+                EphemeralCoins.Logger.LogWarning("ProperSave: failed to restore ephemeral coins: " + ex);
+            }
         }
     }
 

--- a/ModCompatibility.cs
+++ b/ModCompatibility.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using BepInEx.Configuration;
 using RiskOfOptions.OptionConfigs;
 using RiskOfOptions.Options;
+using RoR2;
+using UnityEngine;
 
 namespace EphemeralCoins
 {
@@ -12,6 +15,17 @@ namespace EphemeralCoins
         public const string SaveDataKey = "EphemeralCoins.coinCounts";
 
         private static bool? _enabled;
+        private static List<EphemeralCoinSaveEntry> _lastRestored;
+        private static int _preserveLoadId;
+        private static int _loadId;
+        private static int _delayedReapplyLoadId;
+        private static bool _stageHooked;
+
+        /// <summary>
+        /// True only during the current ProperSave load window (OnLoadingEnded → first stage gather).
+        /// </summary>
+        public static bool ShouldPreserveRestoredCoins =>
+            _preserveLoadId != 0 && _preserveLoadId == _loadId && _lastRestored != null;
 
         public static bool enabled
         {
@@ -31,17 +45,52 @@ namespace EphemeralCoins
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public static bool IsLoading()
+        {
+            try
+            {
+                return ProperSave.Loading.IsLoading;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void Setup()
         {
             ProperSave.SaveFile.OnGatherSaveData += OnGatherSaveData;
             ProperSave.Loading.OnLoadingEnded += OnLoadingEnded;
+            if (!_stageHooked)
+            {
+                Stage.onStageStartGlobal += OnStageStartGlobal;
+                Run.onRunDestroyGlobal += OnRunDestroyGlobal;
+                _stageHooked = true;
+            }
             EphemeralCoins.Logger.LogInfo("ProperSave compatibility enabled (ephemeral coin save/load).");
+        }
+
+        private static void OnRunDestroyGlobal(Run run)
+        {
+            ClearRestoredSnapshot();
+            if (EphemeralCoins.instance != null)
+            {
+                EphemeralCoins.instance.coinCounts.Clear();
+                EphemeralCoins.instance.restoredCoinCountsFromSave = false;
+            }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void OnGatherSaveData(Dictionary<string, object> dict)
         {
             if (EphemeralCoins.instance == null) return;
+
+            if (ShouldPreserveRestoredCoins)
+            {
+                EphemeralCoins.instance.ApplySavedCoinCounts(_lastRestored);
+            }
+            _preserveLoadId = 0;
 
             List<EphemeralCoinSaveEntry> entries = new List<EphemeralCoinSaveEntry>();
             foreach (CoinStorage player in EphemeralCoins.instance.coinCounts)
@@ -68,12 +117,58 @@ namespace EphemeralCoins
                     return;
                 }
 
-                EphemeralCoins.instance.ApplySavedCoinCounts(entries);
+                _loadId++;
+                _preserveLoadId = _loadId;
+                _delayedReapplyLoadId = _loadId;
+                _lastRestored = CloneList(entries);
+                EphemeralCoins.instance.ApplySavedCoinCounts(_lastRestored);
+                EphemeralCoins.instance.StartCoroutine(PostLoadReapplyCoroutine(_loadId));
             }
             catch (Exception ex)
             {
                 EphemeralCoins.Logger.LogWarning("ProperSave: failed to restore ephemeral coins: " + ex);
             }
+        }
+
+        private static void OnStageStartGlobal(Stage stage)
+        {
+            if (!ShouldPreserveRestoredCoins || EphemeralCoins.instance == null) return;
+            EphemeralCoins.instance.ApplySavedCoinCounts(_lastRestored);
+        }
+
+        private static IEnumerator PostLoadReapplyCoroutine(int loadId)
+        {
+            yield return new WaitForSeconds(1f);
+            if (loadId != _delayedReapplyLoadId || _lastRestored == null || EphemeralCoins.instance == null) yield break;
+            EphemeralCoins.instance.ApplySavedCoinCounts(_lastRestored);
+            EphemeralCoins.Logger.LogDebug("ProperSave: re-applied ephemeral coin snapshot after load settle.");
+            if (_preserveLoadId == 0) _lastRestored = null;
+        }
+
+        public static void ClearRestoredSnapshot()
+        {
+            _loadId++;
+            _preserveLoadId = 0;
+            _delayedReapplyLoadId = 0;
+            _lastRestored = null;
+        }
+
+        private static List<EphemeralCoinSaveEntry> CloneList(List<EphemeralCoinSaveEntry> source)
+        {
+            List<EphemeralCoinSaveEntry> copy = new List<EphemeralCoinSaveEntry>(source.Count);
+            foreach (EphemeralCoinSaveEntry entry in source)
+            {
+                if (entry == null) continue;
+                copy.Add(new EphemeralCoinSaveEntry
+                {
+                    idValue = entry.idValue,
+                    idStr = entry.idStr,
+                    idSub = entry.idSub,
+                    name = entry.name,
+                    count = entry.count
+                });
+            }
+            return copy;
         }
     }
 

--- a/NetworkUserIdAccess.cs
+++ b/NetworkUserIdAccess.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using RoR2;
+
+namespace EphemeralCoins
+{
+	/// <summary>
+	/// NetworkUserId.value/strValue/subId are often non-public on runtime RoR2.dll
+	/// (GameLibs publicizer is compile-only).
+	/// </summary>
+	internal static class NetworkUserIdAccess
+	{
+		private static readonly FieldInfo ValueField = typeof(NetworkUserId).GetField(
+			"value", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		private static readonly FieldInfo StrValueField = typeof(NetworkUserId).GetField(
+			"strValue", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		private static readonly FieldInfo SubIdField = typeof(NetworkUserId).GetField(
+			"subId", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+		private static readonly PropertyInfo ValueProp = typeof(NetworkUserId).GetProperty(
+			"value", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		private static readonly PropertyInfo StrValueProp = typeof(NetworkUserId).GetProperty(
+			"strValue", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		private static readonly PropertyInfo SubIdProp = typeof(NetworkUserId).GetProperty(
+			"subId", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+		public static ulong GetValue(NetworkUserId id)
+		{
+			object boxed = id;
+			if (ValueField != null) return (ulong)ValueField.GetValue(boxed);
+			if (ValueProp != null) return (ulong)ValueProp.GetValue(boxed);
+			return 0UL;
+		}
+
+		public static string GetStrValue(NetworkUserId id)
+		{
+			object boxed = id;
+			if (StrValueField != null) return StrValueField.GetValue(boxed) as string;
+			if (StrValueProp != null) return StrValueProp.GetValue(boxed) as string;
+			return null;
+		}
+
+		public static byte GetSubId(NetworkUserId id)
+		{
+			object boxed = id;
+			if (SubIdField != null) return (byte)SubIdField.GetValue(boxed);
+			if (SubIdProp != null) return (byte)SubIdProp.GetValue(boxed);
+			return 0;
+		}
+	}
+}

--- a/NewMoonArtifactManager.cs
+++ b/NewMoonArtifactManager.cs
@@ -7,105 +7,221 @@ namespace EphemeralCoins
 {
 	public static class NewMoonArtifactManager
 	{
+		private static bool runStartHooked;
+
 		[SystemInitializer(new Type[] { typeof(ArtifactCatalog) })]
 		private static void Init()
 		{
-            EphemeralCoins.Logger.LogDebug("NewMoonArtifactManager initialized");
-            RunArtifactManager.onArtifactEnabledGlobal += OnArtifactEnabled;
-            RunArtifactManager.onArtifactDisabledGlobal += OnArtifactDisabled;
-        }
+			EphemeralCoins.Logger.LogDebug("NewMoonArtifactManager initialized");
+			RunArtifactManager.onArtifactEnabledGlobal += OnArtifactEnabled;
+			RunArtifactManager.onArtifactDisabledGlobal += OnArtifactDisabled;
+		}
 
 		private static void OnArtifactEnabled(RunArtifactManager runArtifactManager, ArtifactDef artifactDef)
 		{
-			if (!(artifactDef != Assets.NewMoonArtifact))
+			if (artifactDef != Assets.NewMoonArtifact)
 			{
-                EphemeralCoins.Logger.LogDebug("OnArtifactEnabled hook applied");
-                On.RoR2.Run.Start += Run_Start;
+				return;
+			}
+
+			EphemeralCoins.Logger.LogDebug("OnArtifactEnabled hook applied");
+			if (!runStartHooked)
+			{
+				On.RoR2.Run.Start += Run_Start;
+				runStartHooked = true;
+			}
+
+			// If a run is already underway, apply immediately without waiting for the next Start.
+			if (Run.instance)
+			{
+				SafePrefabSetup(true);
 			}
 		}
 
-        private static void Run_Start(On.RoR2.Run.orig_Start orig, Run self)
-        {
-            EphemeralCoins.Logger.LogDebug("Artifact enabled");
-            PrefabSetup(true);
-            orig(self);
-        }
-
-        private static void OnArtifactDisabled(RunArtifactManager runArtifactManager, ArtifactDef artifactDef)
+		private static void Run_Start(On.RoR2.Run.orig_Start orig, Run self)
 		{
-			if (!(artifactDef != Assets.NewMoonArtifact))
-			{
-                On.RoR2.Run.Start -= Run_Start;
-                EphemeralCoins.Logger.LogDebug("Artifact disabled");
-                PrefabSetup(false);
-            }
+			// Always let vanilla (and other mods) finish run init first. PrefabSetup must never block spawn.
+			orig(self);
+			EphemeralCoins.Logger.LogDebug("Artifact enabled");
+			SafePrefabSetup(true);
 		}
 
-        public static void PrefabSetup(bool set = false)
-        {
-            EphemeralCoins.Logger.LogDebug("PrefabSetup " + set);
+		private static void OnArtifactDisabled(RunArtifactManager runArtifactManager, ArtifactDef artifactDef)
+		{
+			if (artifactDef != Assets.NewMoonArtifact)
+			{
+				return;
+			}
 
-            ///
-            /// Swap the Lunar Coin's model and pickup settings around based on whether the artifact is enabled.
-            ///
-            //Text stuff
-            PickupDef TheCoinDef = PickupCatalog.FindPickupIndex("LunarCoin.Coin0").pickupDef;
-            TheCoinDef.nameToken = set ? "Ephemeral Coin" : "PICKUP_LUNAR_COIN";
-            TheCoinDef.interactContextToken = set ? "Pick up Ephemeral Coin" : "LUNAR_COIN_PICKUP_CONTEXT";
+			if (runStartHooked)
+			{
+				On.RoR2.Run.Start -= Run_Start;
+				runStartHooked = false;
+			}
+			EphemeralCoins.Logger.LogDebug("Artifact disabled");
+			SafePrefabSetup(false);
+		}
 
-            //Outline color
-            TheCoinDef.baseColor = set ? new Color32(96, 254, byte.MaxValue, byte.MaxValue) : new Color32(48, 127, byte.MaxValue, byte.MaxValue);
+		public static void PrefabSetup(bool set = false)
+		{
+			SafePrefabSetup(set);
+		}
 
-            //Chatbox color
-            TheCoinDef.darkColor = set ? new Color32(152, 168, byte.MaxValue, byte.MaxValue) : new Color32(76, 84, 144, byte.MaxValue);
+		private static void SafePrefabSetup(bool set)
+		{
+			try
+			{
+				PrefabSetupInternal(set);
+			}
+			catch (Exception ex)
+			{
+				EphemeralCoins.Logger.LogError("PrefabSetup failed (run init will continue): " + ex);
+			}
+		}
 
-            //Filling our Lunar Coin's hole.
-            GameObject TheCoin = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/LunarCoin/PickupLunarCoin.prefab").WaitForCompletion();
-            TheCoin.transform.Find("Coin5Mesh").GetComponent<MeshFilter>().mesh = set ?
-                Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Common/VFX/mdlLunarCoin.fbx").WaitForCompletion().GetComponent<MeshFilter>().mesh
-                :
-                Addressables.LoadAssetAsync<GameObject>("RoR2/Base/Common/VFX/mdlLunarCoinWithHole.fbx").WaitForCompletion().GetComponent<MeshFilter>().mesh;
+		private static void PrefabSetupInternal(bool set)
+		{
+			EphemeralCoins.Logger.LogDebug("PrefabSetup " + set);
 
-            //Changing the material used for rendering, so we can have a semi-transparent effect. Hopoo's standard shader doesn't do transparency I guess???
-            TheCoin.transform.Find("Coin5Mesh").GetComponent<MeshRenderer>().material = set ? Assets.mainBundle.LoadAsset<Material>("matEphemeralCoin") : Addressables.LoadAssetAsync<Material>("RoR2/Base/Common/VFX/matLunarCoinPlaceholder.mat").WaitForCompletion();
+			///
+			/// Swap the Lunar Coin's model and pickup settings around based on whether the artifact is enabled.
+			///
+			PickupIndex coinIndex = PickupCatalog.FindPickupIndex("LunarCoin.Coin0");
+			PickupDef TheCoinDef = coinIndex.pickupDef;
+			if (TheCoinDef == null)
+			{
+				EphemeralCoins.Logger.LogWarning("PrefabSetup: LunarCoin.Coin0 pickup def missing; skipping coin visual updates.");
+			}
+			else
+			{
+				TheCoinDef.nameToken = set ? "Ephemeral Coin" : "PICKUP_LUNAR_COIN";
+				TheCoinDef.interactContextToken = set ? "Pick up Ephemeral Coin" : "LUNAR_COIN_PICKUP_CONTEXT";
+				TheCoinDef.baseColor = set ? new Color32(96, 254, byte.MaxValue, byte.MaxValue) : new Color32(48, 127, byte.MaxValue, byte.MaxValue);
+				TheCoinDef.darkColor = set ? new Color32(152, 168, byte.MaxValue, byte.MaxValue) : new Color32(76, 84, 144, byte.MaxValue);
+			}
 
-            ///
-            /// Changing the interactable costs.
-            ///
-            /// Only the LunarChest (pods) and FrogInteractable (moonfrog) actually do anything here, because Bazaar is full of pre-loaded instances of the prefabs.
-            /// Still change the other prefabs anyway, just in case Hopoo decides to change something down the line.
-            /// The Seer Stations will always require hooks, because their scripts set their price at runtime. Why? Ask Hopoo.
-            foreach (string x in Assets.lunarInteractables)
-            {
-                GameObject z = Addressables.LoadAssetAsync<GameObject>(x).WaitForCompletion();
-                int zValue = 0;
+			GameObject TheCoin = LoadAddressable<GameObject>(Assets.PickupLunarCoin);
+			Transform coinMesh = FindCoinMesh(TheCoin);
+			if (TheCoin == null || coinMesh == null)
+			{
+				EphemeralCoins.Logger.LogWarning("PrefabSetup: could not locate lunar coin mesh transform; skipping mesh/material swap.");
+			}
+			else
+			{
+				MeshFilter meshFilter = coinMesh.GetComponent<MeshFilter>();
+				MeshRenderer meshRenderer = coinMesh.GetComponent<MeshRenderer>();
+				if (meshFilter)
+				{
+					GameObject meshSource = LoadAddressable<GameObject>(set ? Assets.LunarCoinMesh : Assets.LunarCoinWithHoleMesh);
+					MeshFilter sourceFilter = meshSource ? meshSource.GetComponent<MeshFilter>() : null;
+					if (sourceFilter && sourceFilter.sharedMesh)
+					{
+						meshFilter.sharedMesh = sourceFilter.sharedMesh;
+					}
+					else
+					{
+						EphemeralCoins.Logger.LogWarning("PrefabSetup: failed to load replacement lunar coin mesh.");
+					}
+				}
 
-                switch (z.name)
-                {
-                    case "LunarRecycler":
-                        zValue = (int)BepConfig.RerollCost.Value;
-                        break;
-                    case "LunarChest":
-                        zValue = (int)BepConfig.PodCost.Value;
-                        break;
-                    case "LunarShopTerminal":
-                        zValue = (int)BepConfig.ShopCost.Value;
-                        break;
-                    case "SeerStation":
-                        zValue = (int)BepConfig.SeerCost.Value;
-                        break;
-                    case "FrogInteractable":
-                        zValue = (int)BepConfig.FrogCost.Value;
-                        z.GetComponent<FrogController>().maxPets = (int)BepConfig.FrogPets.Value;
-                        break;
-                    default:
-                        EphemeralCoins.Logger.LogWarning("Unknown lunarInteractable " + x + ", will default to 0 cost!");
-                        break;
-                }
+				if (meshRenderer)
+				{
+					Material mat = set
+						? Assets.mainBundle.LoadAsset<Material>("matEphemeralCoin")
+						: LoadAddressable<Material>(Assets.LunarCoinPlaceholderMat);
+					if (mat)
+					{
+						meshRenderer.sharedMaterial = mat;
+					}
+					else
+					{
+						EphemeralCoins.Logger.LogWarning("PrefabSetup: failed to load lunar coin material.");
+					}
+				}
+			}
 
-                z.GetComponent<PurchaseInteraction>().Networkcost = zValue;
-                if (zValue == 0) { z.GetComponent<PurchaseInteraction>().costType = CostTypeIndex.None; }
-            }
-        }
-    }
+			///
+			/// Changing the interactable costs.
+			///
+			/// Only the LunarChest (pods) and FrogInteractable (moonfrog) actually do anything here, because Bazaar is full of pre-loaded instances of the prefabs.
+			/// Still change the other prefabs anyway, just in case Hopoo decides to change something down the line.
+			/// The Seer Stations will always require hooks, because their scripts set their price at runtime. Why? Ask Hopoo.
+			foreach (string x in Assets.lunarInteractables)
+			{
+				GameObject z = LoadAddressable<GameObject>(x);
+				if (!z)
+				{
+					EphemeralCoins.Logger.LogWarning("PrefabSetup: failed to load lunarInteractable " + x);
+					continue;
+				}
+
+				int zValue = 0;
+				switch (z.name)
+				{
+					case "LunarRecycler":
+						zValue = (int)BepConfig.RerollCost.Value;
+						break;
+					case "LunarChest":
+						zValue = (int)BepConfig.PodCost.Value;
+						break;
+					case "LunarShopTerminal":
+						zValue = (int)BepConfig.ShopCost.Value;
+						break;
+					case "SeerStation":
+						zValue = (int)BepConfig.SeerCost.Value;
+						break;
+					case "FrogInteractable":
+						zValue = (int)BepConfig.FrogCost.Value;
+						FrogController frog = z.GetComponent<FrogController>();
+						if (frog) frog.maxPets = (int)BepConfig.FrogPets.Value;
+						break;
+					default:
+						EphemeralCoins.Logger.LogWarning("Unknown lunarInteractable " + x + ", will default to 0 cost!");
+						break;
+				}
+
+				PurchaseInteraction purchase = z.GetComponent<PurchaseInteraction>();
+				if (!purchase)
+				{
+					EphemeralCoins.Logger.LogWarning("PrefabSetup: PurchaseInteraction missing on " + x);
+					continue;
+				}
+
+				// Write the backing field on the shared prefab. Networkcost/SetSyncVar on Addressable
+				// prefab assets can corrupt client network state during run start.
+				purchase.cost = zValue;
+				if (zValue == 0)
+				{
+					purchase.costType = CostTypeIndex.None;
+				}
+			}
+		}
+
+		private static T LoadAddressable<T>(string key) where T : UnityEngine.Object
+		{
+			try
+			{
+				return Addressables.LoadAssetAsync<T>(key).WaitForCompletion();
+			}
+			catch (Exception ex)
+			{
+				EphemeralCoins.Logger.LogWarning("PrefabSetup: Addressables key failed (" + key + "): " + ex.Message);
+				return null;
+			}
+		}
+
+		private static Transform FindCoinMesh(GameObject coinPrefab)
+		{
+			if (!coinPrefab) return null;
+
+			Transform mesh = coinPrefab.transform.Find("Coin5Mesh");
+			if (mesh) return mesh;
+
+			mesh = coinPrefab.transform.Find("LunarCoinMesh");
+			if (mesh) return mesh;
+
+			MeshFilter filter = coinPrefab.GetComponentInChildren<MeshFilter>(true);
+			return filter ? filter.transform : null;
+		}
+	}
 }

--- a/NewMoonArtifactManager.cs
+++ b/NewMoonArtifactManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using RoR2;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -86,8 +87,8 @@ namespace EphemeralCoins
 			///
 			/// Swap the Lunar Coin's model and pickup settings around based on whether the artifact is enabled.
 			///
-			PickupIndex coinIndex = PickupCatalog.FindPickupIndex("LunarCoin.Coin0");
-			PickupDef TheCoinDef = coinIndex.pickupDef;
+			// Prefer GetPickupDef — PickupIndex.pickupDef is inaccessible on runtime RoR2.dll.
+			PickupDef TheCoinDef = PickupCatalog.GetPickupDef(PickupCatalog.FindPickupIndex("LunarCoin.Coin0"));
 			if (TheCoinDef == null)
 			{
 				EphemeralCoins.Logger.LogWarning("PrefabSetup: LunarCoin.Coin0 pickup def missing; skipping coin visual updates.");
@@ -172,8 +173,15 @@ namespace EphemeralCoins
 						break;
 					case "FrogInteractable":
 						zValue = (int)BepConfig.FrogCost.Value;
+						// maxPets is not publicly accessible on runtime RoR2.dll (publicizer is compile-only).
 						FrogController frog = z.GetComponent<FrogController>();
-						if (frog) frog.maxPets = (int)BepConfig.FrogPets.Value;
+						if (frog)
+						{
+							FieldInfo maxPets = typeof(FrogController).GetField(
+								"maxPets",
+								BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+							maxPets?.SetValue(frog, (int)BepConfig.FrogPets.Value);
+						}
 						break;
 					default:
 						EphemeralCoins.Logger.LogWarning("Unknown lunarInteractable " + x + ", will default to 0 cost!");

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Provides settings to control various aspects relating to Lunar Coins, including 
 
 ## Changelog
 
+2.3.9 - Fix ephemeral coin counter not updating and bazaar purchases with 0 coins: key coin storage by NetworkUserId, always initialize storage (including ProperSave loads), and never fall back to profile lunar coins while the artifact is active.
+
 2.3.8 - Fix multiplayer clients spawning dead/off-map: run PrefabSetup after Run.Start, update Addressable keys for current game paths, avoid SetSyncVar on shared prefabs, and harden PrefabSetup/IL hook failures so they cannot abort run init.
 
 2.3.7 - fixed for ac

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Provides settings to control various aspects relating to Lunar Coins, including 
 
 ## Changelog
 
+2.3.8 - Fix multiplayer clients spawning dead/off-map: run PrefabSetup after Run.Start, update Addressable keys for current game paths, avoid SetSyncVar on shared prefabs, and harden PrefabSetup/IL hook failures so they cannot abort run init.
+
 2.3.7 - fixed for ac
 
 2.3.6 - fixed for sots 2.0

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ Provides settings to control various aspects relating to Lunar Coins, including 
 - Lunar Reroller won't let you reroll if you've already bought the entire store, even if the config is set to refresh the lineup.
 - Very little multiplayer testing has been done. Please report any bugs on [Github](https://github.com/VarnaScelestus/RoR2).
 
-## Todo
-
-- Re-implement [ProperSave](https://thunderstore.io/package/KingEnderBrine/ProperSave/) compatibility.
-
 ## Credits
 
 [Magnus](https://github.com/MagnusMagnuson/RoR2Mods) - For the original code this was forked from. Not only was it an excellent starting point, it helped me learn a lot too!
@@ -35,6 +31,8 @@ Provides settings to control various aspects relating to Lunar Coins, including 
 [RoR2 modding discord](https://discord.gg/5MbXZvd) - For help in figuring out the Slab (Lunar Reroller)'s horrible, horrible internal structure, and just being awesome in general!
 
 ## Changelog
+
+2.3.10 - Restore ProperSave compatibility: ephemeral coin balances are saved/loaded with the run using stable NetworkUserId keys.
 
 2.3.9 - Fix ephemeral coin counter not updating and bazaar purchases with 0 coins: key coin storage by NetworkUserId, always initialize storage (including ProperSave loads), and never fall back to profile lunar coins while the artifact is active.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Ephemeral_Coins",
-    "version_number": "2.3.9",
+    "version_number": "2.3.10",
     "website_url": "https://github.com/prodzpod/EphemeralCoins",
     "description": "Lunar Coins become a per-run currency via artifact. Seperate configs for drop chance, BTB costs, etc.",
     "dependencies": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Ephemeral_Coins",
-    "version_number": "2.3.8",
+    "version_number": "2.3.9",
     "website_url": "https://github.com/prodzpod/EphemeralCoins",
     "description": "Lunar Coins become a per-run currency via artifact. Seperate configs for drop chance, BTB costs, etc.",
     "dependencies": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Ephemeral_Coins",
-    "version_number": "2.3.7",
+    "version_number": "2.3.8",
     "website_url": "https://github.com/prodzpod/EphemeralCoins",
     "description": "Lunar Coins become a per-run currency via artifact. Seperate configs for drop chance, BTB costs, etc.",
     "dependencies": [


### PR DESCRIPTION
## Summary
- Run PrefabSetup after `Run.Start`, update Addressable keys, and avoid `Networkcost`/SetSyncVar on shared prefabs so clients no longer spawn dead/off-map
- Key ephemeral coin storage by `NetworkUserId` and always initialize it when the artifact is active so pickups update the HUD counter
- While the artifact is active, lunar shop affordability uses ephemeral coins only (no fallback to profile lunar coins at 0 balance)
- Restore ProperSave compatibility: ephemeral balances are saved/loaded with the run using stable NetworkUserId entries
- Avoid runtime publicizer traps: reflect `HUD._localUserViewer`, `NetworkUserId` fields, and `FrogController.maxPets`; use `PickupCatalog.GetPickupDef`; mutate LunarCoin `isAffordable` instead of private `CostTypeCatalog.Register`
- Re-apply PrefabSetup on `Run.Start` so always-on mode gets coin visuals after PickupCatalog is ready
- After ProperSave reload, rebind coin storage by display name when NetworkUserId shape differs, push full balances to clients, and ignore award/deduct during load so clients keep restored counts

## Test plan
- [x] Host + client multiplayer with Artifact of the New Moon enabled
- [x] Confirm clients spawn normally (not dead / off-map)
- [x] Pick up ephemeral coins and confirm the HUD counter increases (no FieldAccessException spam)
- [x] Confirm ephemeral coin name/mesh/material apply (always-on and artifact modes)
- [x] With 0 ephemeral coins, confirm bazaar/lunar shops cannot be purchased
- [x] With ProperSave: save mid-run with N coins, reload, confirm count is still N for host and clients
- [x] Fresh run after ProperSave session starts at 0 coins
- [x] Confirm plugin loads as 2.3.10 in logs